### PR TITLE
ci: upgrade deprecated GitHub Actions (Node.js 20 deprecation)

### DIFF
--- a/.github/workflows/friends-auto-merge.yml
+++ b/.github/workflows/friends-auto-merge.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.repository_owner == 'Besty0728'
     steps:
       - name: Checkout Base (safe context)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
@@ -57,7 +57,7 @@ jobs:
 
       - name: Checkout PR Head
         if: steps.verify.outputs.status == 'pass'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
@@ -169,13 +169,13 @@ jobs:
 
       - name: Install pnpm
         if: steps.gate.outputs.status == 'pass'
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Set up Node.js
         if: steps.gate.outputs.status == 'pass'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 22
           cache: "pnpm"
 
       - name: Install dependencies

--- a/.github/workflows/github-contributions.yml
+++ b/.github/workflows/github-contributions.yml
@@ -16,14 +16,14 @@ jobs:
   update-contributions:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Fetch GitHub contributions data
         env:

--- a/.github/workflows/hot-ranking-check.yml
+++ b/.github/workflows/hot-ranking-check.yml
@@ -16,7 +16,7 @@ jobs:
   check-ranking:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/indexnow.yml
+++ b/.github/workflows/indexnow.yml
@@ -21,15 +21,15 @@ jobs:
     
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
-      
+      uses: actions/checkout@v7
+
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
-        node-version: '18'
+        node-version: '22'
         
     - name: Setup pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
       with:
         version: 9.15.9
         
@@ -38,7 +38,7 @@ jobs:
 
     # 恢复上次的提交记录缓存
     - name: Restore IndexNow submission cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v6
       id: cache-restore
       with:
         path: .indexnow-submitted.json
@@ -74,7 +74,7 @@ jobs:
 
     # 保存更新后的提交记录到缓存
     - name: Save IndexNow submission cache
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v6
       if: always()
       with:
         path: .indexnow-submitted.json


### PR DESCRIPTION
GitHub 已弃用 Actions runners 上的 Node.js 20，相关 action 被强制在 Node.js 24 上运行并产生警告，未来会变为失败。

升级内容：
- `actions/checkout` v4 → v7
- `actions/setup-node` v4 → v7
- `actions/cache` v4 → v6
- `pnpm/action-setup` v4 → v6
- Node.js 18/20 → 22 (LTS)

涉及所有 4 个 workflow 文件。